### PR TITLE
Flexible custom claims and bug fixes

### DIFF
--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -8,6 +8,7 @@
 + Fixed generation of JWT to use correct Base64url Encoding.
 + Added general support for non-registered claims.
 + Tidy up for static analysis and Dart linter.
++ Implemented toString method for JwtClaim.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 + Added support for optional Not Before (`nbf`) time claims.
 + Fixed validation to reject token when current time equals the Expiry time.
++ Added support for custom payload name.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-+ 2.1.2
+## TBD
+
++ Added support for optional Not Before (`nbf`) time claims.
++ Fixed validation to reject token when current time equals the Expiry time.
+
+## 2.1.2
 
 + Fixed when `typ` is not present
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 + Added support for optional Not Before (`nbf`) time claims.
 + Fixed validation to reject token when current time equals the Expiry time.
-+ Added support for custom payload name.
 + Added more validation unit tests.
 + Fixed generation of JWT to use correct Base64url Encoding.
++ Added general support for non-registered claims.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -7,6 +7,7 @@
 + Added more validation unit tests.
 + Fixed generation of JWT to use correct Base64url Encoding.
 + Added general support for non-registered claims.
++ Tidy up for static analysis and Dart linter.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -6,6 +6,7 @@
 + Fixed validation to reject token when current time equals the Expiry time.
 + Added support for custom payload name.
 + Added more validation unit tests.
++ Fixed generation of JWT to use correct Base64url Encoding.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -5,6 +5,7 @@
 + Added support for optional Not Before (`nbf`) time claims.
 + Fixed validation to reject token when current time equals the Expiry time.
 + Added support for custom payload name.
++ Added more validation unit tests.
 
 ## 2.1.2
 

--- a/jaguar_jwt/README.md
+++ b/jaguar_jwt/README.md
@@ -41,7 +41,7 @@ To process a JWT:
 ```dart
   try {
     final JwtClaim decClaimSet = verifyJwtHS256Signature(token, key);
-    // print(decClaimSet.toJson());
+    // print(decClaimSet);
 
     decClaimSet.validate(issuer: 'teja', audience: 'audience1.example.com');
 

--- a/jaguar_jwt/analysis_options.yaml
+++ b/jaguar_jwt/analysis_options.yaml
@@ -4,9 +4,17 @@
 #   https://www.dartlang.org/guides/language/analysis-options
 
 analyzer:
-  exclude:
-    - path/to/excluded/files/**
-# linter:
-#   rules:
-#     # see catalog here: http://dart-lang.github.io/linter/lints/
-#     - hash_and_equals
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    # see catalog here: http://dart-lang.github.io/linter/lints/
+    - always_put_control_body_on_new_line
+    - camel_case_types
+    # - omit_local_variable_types
+    - prefer_single_quotes
+    - public_member_api_docs
+    - sort_constructors_first
+    - type_annotate_public_apis

--- a/jaguar_jwt/example/example.dart
+++ b/jaguar_jwt/example/example.dart
@@ -36,7 +36,7 @@ void receiverProcessesJwt(String token) {
   try {
     // Verify the signature in the JWT and extract its claim set
     final decClaimSet = verifyJwtHS256Signature(token, sharedSecret);
-    print(decClaimSet.toJson());
+    print('JwtClaim: $decClaimSet\n');
 
     // Validate the claim set
 
@@ -45,16 +45,16 @@ void receiverProcessesJwt(String token) {
     // Use values from claim set
 
     if (decClaimSet.subject != null) {
-      print('JWT_ID: "${decClaimSet.jwtId}"');
+      print('JWT ID: "${decClaimSet.jwtId}"');
     }
     if (decClaimSet.jwtId != null) {
-      print('subject: "${decClaimSet.subject}"');
+      print('Subject: "${decClaimSet.subject}"');
     }
     if (decClaimSet.issuedAt != null) {
-      print('iat: ${decClaimSet.issuedAt}');
+      print('Issued At: ${decClaimSet.issuedAt}');
     }
     if (decClaimSet.containsKey('typ')) {
-      dynamic v = decClaimSet['typ'];
+      final dynamic v = decClaimSet['typ'];
       if (v is String) {
         print('typ: "$v"');
       } else {

--- a/jaguar_jwt/example/example.dart
+++ b/jaguar_jwt/example/example.dart
@@ -1,19 +1,59 @@
-library jaguar_jwt.example;
+import 'dart:math';
 
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 
-void main() {
-  final key = 'dfsdffasdfdgdfgdfg456456456';
-  final claimSet = new JwtClaim(
-      subject: 'kleak',
-      issuer: 'teja',
-      audience: <String>['example.com', 'hello.com'],
-      payload: {'k': 'v'});
-  String token = issueJwtHS256(claimSet, key);
-  print(token);
+const sharedSecret = 's3cr3t';
 
-  final JwtClaim decClaimSet = verifyJwtHS256Signature(token, key);
+void main() {
+  final jwt = senderCreatesJwt();
+  receiverProcessesJwt(jwt);
+}
+
+String senderCreatesJwt() {
+  // Create a claim set
+
+  final claimSet = new JwtClaim(
+      issuer: 'teja',
+      subject: 'kleak',
+      audience: <String>['client1.example.com', 'client2.example.com'],
+      jwtId: _randomString(32),
+      otherClaims: {
+        'typ': 'authnresponse',
+        'pld': {'k': 'v'}
+      },
+      maxAge: const Duration(minutes: 5));
+
+  // Generate a JWT from the claim set
+
+  final token = issueJwtHS256(claimSet, sharedSecret);
+
+  print('jwt = "$token"');
+
+  return token;
+}
+
+void receiverProcessesJwt(String token) {
+  // Verify the signature in the JWT and extract its claim set
+
+  final JwtClaim decClaimSet = verifyJwtHS256Signature(token, sharedSecret);
+
   print(decClaimSet.toJson());
 
-  decClaimSet.validate(issuer: 'teja', audience: 'hello.com');
+  // Validate the claim set
+
+  decClaimSet.validate(issuer: 'teja', audience: 'client2.example.com');
+
+  assert(decClaimSet.subject == 'kleak');
+  assert(decClaimSet.jwtId.isNotEmpty); // should check for uniqueness
+}
+
+const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+String _randomString(int length) {
+  final rnd = new Random(new DateTime.now().millisecondsSinceEpoch);
+  var buf = new StringBuffer();
+
+  for (var x = 0; x < length; x++) {
+    buf.write(chars[rnd.nextInt(chars.length)]);
+  }
+  return buf.toString();
 }

--- a/jaguar_jwt/lib/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/jaguar_jwt.dart
@@ -2,6 +2,57 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 /// JWT support for Jaguar.dart web server
+///
+/// This library can be used to generate and process JSON Web Tokens (JWT).
+/// For more information about JSON Web Tokens, see
+/// [RFC 7519](https://tools.ietf.org/html/rfc7519).
+///
+/// Currently, only the HMAC SHA-256 algorithm is supported to generate/process
+/// a JSON Web Signature (JWS).
+///
+/// To generate a JWT, create a [JwtClaim] and use [issueJwtHS256]:
+///
+/// ```
+/// final claimSet = new JwtClaim(
+///      issuer: 'issuer.example.com',
+///      subject: 'BD4A3FC4-9861-4171-8640-20C3004BD059',
+///      audience: <String>['client1.example.com', 'client2.example.com'],
+///      jwtId: _randomString(32),
+///      otherClaims: <String,dynamic>{
+///        'typ': 'authnresponse',
+///        'pld': {'k': 'v'}
+///      },
+///      maxAge: const Duration(minutes: 5));
+///
+/// // Generate a JWT from the claim set
+///
+/// final token = issueJwtHS256(claimSet, sharedSecret);
+/// ```
+///
+/// To process a JWT, use [verifyJwtHS256Signature] to verify its signature
+/// and to extract a claim set from it, then verify the claim set using the
+/// [JwtClaim.validate] method before using the claims from it.
+///
+/// ```
+/// const _expectedIssuer = 'issuer.example.com';
+/// const _thisClient = 'client1.example.com';
+///
+/// try {
+///   final claimSet = verifyJwtHS256Signature(token, sharedSecret);
+///
+///   claimSet.validate(issuer: _expectedIssuer,  audience: _thisClient);
+///
+///   final tokenIdentifier = claimSet.jwtId;
+///   final claimSubject = claimSet.subject;
+///   if (claimSet.containsKey('typ')) {
+///     final typValue = claimSet['typ'];
+///     ...
+///   }
+///   ...
+/// } on JwtException {
+///    ...
+/// }
+/// ```
 library jaguar_jwt;
 
 export 'src/jaguar_jwt.dart';

--- a/jaguar_jwt/lib/src/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/src/jaguar_jwt.dart
@@ -61,13 +61,16 @@ class JwtException {
 ///     print(decClaimSet.toJson());
 class JwtClaim {
   /// Subject to which the token is issued
+  ///
+  /// Fills the `sub` claim in the JWT token.
   final String subject;
 
   /// Issuer of the token. Is optional.
   ///
   /// Authority issuing the token. This will be used during authorization to verify
   /// that expected issuer has issued the token.
-  /// Fills the `iss` field of the JWT token.
+  ///
+  /// Fills the `iss` claim in the JWT token.
   final String issuer;
 
   /// List of audience that accept this token.
@@ -77,30 +80,39 @@ class JwtClaim {
   final List<String> audience;
 
   /// When the token was issued
+  ///
+  /// Fills the `iat` claim in the JWT token.
   final DateTime issuedAt;
 
-  /// When the token becomes valid (optional: null if not set)
+  /// When the token becomes valid. Is optional.
+  ///
+  /// Fills the `nbf` claim in the JWT token.
   final DateTime notBefore;
 
   /// Time at which the token expires
-  /// Fills `exp` field in JWT token
+  ///
+  /// Fills `exp` claim in the JWT token.
   final DateTime expiry;
 
   /// Unique Id of this JWT token
+  ///
+  /// Fills the `jti` claim in the JWT token.
   final String jwtId;
 
   /// Extra payload
+  ///
+  /// Fills the claim with the name [payloadName] in the JWT token.
   final Map<String, dynamic> payload = new Map<String, dynamic>();
 
   /// Default name of the extra payload
   static const String defaultPayloadName = 'pld';
 
-  /// Name for the extra payload
+  /// Name for the extra payload claim in the JWT token
   final String payloadName;
 
   /// Builds claim set from individual fields
   ///
-  /// The [payload] is optional. The default name of the payload member can
+  /// The [payload] is optional. The default name of the payload claim can
   /// be overridden by providing a [payloadName].
   ///
   /// Note: the Issued At and Expiry time claims are always populated.
@@ -129,7 +141,7 @@ class JwtClaim {
   /// Builds claim set from [Map]
   ///
   /// The [payloadName] is used as the extra payload's name. It is used as the
-  /// key for obtaining the payload from [data], as well as the member name
+  /// key for obtaining the payload from [data], as well as the claim name
   /// in the claim set that is produced.
   ///
   /// If not provided, it defaults to [defaultPayloadName].
@@ -274,7 +286,7 @@ String issueJwtHS256(JwtClaim claimSet, String hmacKey) {
 
 /// Verifies that JWT token is has correct signature.
 ///
-/// The payload in the claim set is taken from the JSON member whose name is
+/// The payload in the claim set is taken from the claim whose name is
 /// 'pld'. This can be changed by providing a different name for [payloadName].
 ///
 /// Returns the decoded claim set.

--- a/jaguar_jwt/lib/src/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/src/jaguar_jwt.dart
@@ -1,5 +1,7 @@
-// Copyright (c) 2016, Ravi Teja Gudapati. All rights reserved. Use of this source code
-// is governed by a BSD-style license that can be found in the LICENSE file.
+// Copyright (c) 2016, 2019, Ravi Teja Gudapati. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
 
 library jaguar_jwt.src;
 
@@ -263,7 +265,10 @@ class JwtClaim {
   }
 }
 
-/// Issues a HS256 based JWT token from given claim set
+/// Issues a HMAC SHA-256 signed JWT.
+///
+/// Creates a JWT using the [claimSet] for the payload and signing it using
+/// the [hmacKey] with the HMAC SHA-256 algorithm.
 ///
 ///     final claimSet = new JwtClaim(
 ///       subject: 'kleak',
@@ -272,19 +277,24 @@ class JwtClaim {
 ///       payload: {'k': 'v'});
 ///       String token = issueJwtHS256(claimSet, key);
 ///       print(token);
+
 String issueJwtHS256(JwtClaim claimSet, String hmacKey) {
   final hmac = new Hmac(sha256, hmacKey.codeUnits);
   final SplayTreeMap<String, String> header =
       new SplayTreeMap.from({"alg": "HS256", "typ": "JWT"});
-  final String headerString = base64UrlEncode(json.encode(header).codeUnits);
-  final String payloadString =
-      base64UrlEncode(json.encode(claimSet.toJson()).codeUnits);
-  final String data = headerString + "." + payloadString;
-  final List<int> signature = hmac.convert(data.codeUnits).bytes;
-  return data + "." + base64UrlEncode(signature);
+
+  final encHdr = B64urlEncRFC7515.encode(json.encode(header).codeUnits);
+  final encPld =
+      B64urlEncRFC7515.encode(json.encode(claimSet.toJson()).codeUnits);
+
+  final data = encHdr + '.' + encPld;
+
+  final encSig = B64urlEncRFC7515.encode(hmac.convert(data.codeUnits).bytes);
+
+  return data + '.' + encSig;
 }
 
-/// Verifies that JWT token is has correct signature.
+/// Verifies that signature and extracts the claim set from a JWT.
 ///
 /// The payload in the claim set is taken from the claim whose name is
 /// 'pld'. This can be changed by providing a different name for [payloadName].
@@ -293,41 +303,53 @@ String issueJwtHS256(JwtClaim claimSet, String hmacKey) {
 ///
 ///     final JwtClaim decClaimSet = verifyJwtHS256Signature(token, key);
 ///     print(decClaimSet.toJson());
+
 JwtClaim verifyJwtHS256Signature(String token, String hmacKey,
     {String payloadName = JwtClaim.defaultPayloadName}) {
-  final hmac = new Hmac(sha256, hmacKey.codeUnits);
-  final List<String> parts = token.split(".");
-
-  if (parts.length != 3) throw JwtException.invalidToken;
-
-  {
-    try {
-      final String headerString = _decodeBase64(parts[0]);
-      final map = json.decode(headerString);
-      if (map is! Map) throw JwtException.invalidToken;
-      if (map['typ'] != null && map['typ'] != 'JWT')
-        throw JwtException.invalidToken;
-      if (map['alg'] != 'HS256') throw JwtException.hashMismatch;
-    } on FormatException catch (_) {
-      throw JwtException.invalidToken;
-    }
-  }
-
-  final String payloadString = _decodeBase64(parts[1]);
-  final String data = parts[0] + "." + parts[1];
-  String signature = base64UrlEncode(hmac.convert(data.codeUnits).bytes);
-
-  if (signature != parts[2]) {
-    signature = signature.substring(0, signature.indexOf('='));
-    if (signature != parts[2]) throw JwtException.hashMismatch;
-  }
-
   try {
-    final map = json.decode(payloadString);
-    if (map is! Map) throw JwtException.invalidToken;
+    final hmac = new Hmac(sha256, hmacKey.codeUnits);
+    final List<String> parts = token.split(".");
 
-    return new JwtClaim.fromMap(map, payloadName: payloadName);
-  } on FormatException catch (_) {
+    if (parts.length != 3) throw JwtException.invalidToken;
+
+    // Decode header and payload
+
+    final headerString = B64urlEncRFC7515.decodeUtf8(parts[0]);
+    final payloadString = B64urlEncRFC7515.decodeUtf8(parts[1]);
+
+    // Verify header
+
+    final header = json.decode(headerString);
+    if (header is! Map)
+      throw JwtException.invalidToken; // is JSON, but not a JSON object
+
+    if (header['typ'] != null && header['typ'] != 'JWT')
+      throw JwtException.invalidToken;
+
+    if (header['alg'] != 'HS256')
+      throw JwtException.hashMismatch; // wrong algorithm
+
+    // Verify signature: calculate signature and compare to token's signature
+
+    final data = parts[0] + '.' + parts[1];
+    final calcSig = B64urlEncRFC7515.encode(hmac.convert(data.codeUnits).bytes);
+
+    if (calcSig != parts[2]) {
+      throw JwtException.hashMismatch; // signature does not match calculated
+    }
+
+    // Convert payload into a claim set
+
+    final payload = json.decode(payloadString);
+    if (payload is! Map)
+      throw JwtException.invalidToken; // is JSON, but not a JSON object
+
+    return new JwtClaim.fromMap(payload, payloadName: payloadName);
+  } on FormatException {
+    // Can be caused by:
+    //   - header or payload parts are not Base64url Encoding
+    //   - bytes in the header or payload are not proper UTF-8
+    //   - string in header or payload cannot be parsed into JSON
     throw JwtException.invalidToken;
   }
 }
@@ -349,23 +371,87 @@ _splay(value) {
     return value;
 }
 
-/// Calls [base64Decode], but also works for strings with lengths
-/// that are *not* multiples of 4.
-String _decodeBase64(String str) {
-  String output = str.replaceAll('-', '+').replaceAll('_', '/');
+//================================================================
+/// Implements "Base64url Encoding" as defined RFC 7515.
+///
+/// Note: the [base64Url] constant from _dart:convert_ implements "base64url"
+/// from RFC 4648, which is NOT THE SAME as "Base64url Encoding" as defined by
+/// RFC 7515.
+///
+/// Essentially, _Base64url Encoding_ is "base64url" without the padding
+/// <https://tools.ietf.org/html/rfc7515#appendix-C>.
 
-  switch (output.length % 4) {
-    case 0:
-      break;
-    case 2:
-      output += '==';
-      break;
-    case 3:
-      output += '=';
-      break;
-    default:
-      throw 'Illegal base64url string!"';
+class B64urlEncRFC7515 {
+  /// Encode bytes using _Base64url Encoding_.
+
+  static String encode(List<int> octets) {
+    final e = base64Url.encode(octets).replaceAll('=', ''); // padding removed
+
+    assert(!e.contains('+')); // check it is using the URL safe alphabet
+    assert(!e.contains('/')); // check it is using the URL safe alphabet
+
+    return e;
   }
 
-  return utf8.decode(base64Decode(output));
+  /// Decodes a _Base64url Encoding_ string value into bytes.
+  ///
+  /// Throws [FormatException] if [str] is not valid Base64url Encoding.
+
+  static List<int> decode(String encoded) {
+    // Detect incorrect "base64url" or normal "base64" encoding
+
+    if (encoded.contains('=')) {
+      throw FormatException; // unexpected padding character
+    }
+    if (encoded.contains('+') || encoded.contains('/')) {
+      throw FormatException; // unexpected character not filename safe
+    }
+
+    // Add padding, if necessary
+
+    var output = encoded;
+    switch (output.length % 4) {
+      case 0:
+        break;
+      case 2:
+        output += '==';
+        break;
+      case 3:
+        output += '=';
+        break;
+      default:
+        throw FormatException; // bad length for a Base64url Encoding
+    }
+
+    // Decode
+
+    return base64Url.decode(output); // this may throw FormatException
+
+    /* Alternative implementation
+    var output = encoded.replaceAll('-', '+').replaceAll('_', '/');
+    (add padding here)
+    return base64Decode(output); // this may throw FormatException
+    */
+  }
+
+  /// Encodes a String into a _Base64url Encoding_ value.
+  ///
+  /// The [str] is encoded using UTF-8, and then those bytes are encoded using
+  /// Base64url Encoding.
+
+  static String encodeUtf8(String str) {
+    return encode(utf8.encode(str));
+  }
+
+  /// Decodes a _Base64url Encoding_ value into a String.
+  ///
+  /// The [str] is decoded as a _Base64url Encoding_, and then those bytes
+  /// are interpreted as a UTF-8 encoded string.
+  ///
+  /// Throws [FormatException] if it is not Base64url Encoding or does not
+  /// contain a UTF-8 encoded string.
+
+  static String decodeUtf8(String encoded) {
+    return utf8.decode(decode(encoded));
+  }
 }

--- a/jaguar_jwt/lib/src/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/src/jaguar_jwt.dart
@@ -82,8 +82,8 @@ class JwtException {
 /// release. It is deprecated. New code should handle the 'pld' claim as any
 /// other non-registered claim.
 ///
-/// ```
 /// Issue token from [JwtClaim]:
+/// ```dart
 ///     final claimSet = new JwtClaim(
 ///       subject: 'kleak',
 ///       issuer: 'teja',
@@ -92,10 +92,12 @@ class JwtException {
 ///
 ///     final token = issueJwtHS256(claimSet, key);
 ///     print(token);
+/// ```
 ///
 /// Parse [JwtClaim] from token:
+/// ```dart
 ///     final decClaimSet = verifyJwtHS256Signature(token, key);
-///     print(decClaimSet.toJson());
+///     print(decClaimSet);
 /// ```
 
 class JwtClaim {
@@ -605,6 +607,21 @@ class JwtClaim {
     // not IssuedAt.
 
     // No checks for JWT ID Claim: the application is supposed to do that
+  }
+
+  //----------------------------------------------------------------
+  /// Converts a JwtClaim into a multi-line String for display.
+
+  @override
+  String toString() {
+    final buf = StringBuffer('{\n');
+
+    for (var claimName in claimNames(includeRegisteredClaims: true)) {
+      buf..write('  $claimName: ')..write(this[claimName])..write('\n');
+    }
+    buf.write('}');
+
+    return buf.toString();
   }
 
   //================================================================

--- a/jaguar_jwt/test/decoding/decoding_test.dart
+++ b/jaguar_jwt/test/decoding/decoding_test.dart
@@ -25,10 +25,27 @@ main() {
               .add(new Duration(days: 1)));
     });
 
-    test('With payload', () {
+    test('With payload: default name (pld)', () {
       String token =
           r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIiOiIxMjM0NTY3ODkwIn0=.8C3WCOzfgAGvO7niu31HrkS_m883Vp8MSs7RMr9gN6g=';
       final JwtClaim claimSet = verifyJwtHS256Signature(token, key);
+      expect(claimSet.issuer, equals('teja'));
+      expect(claimSet.audience, equals(["admin", "students"]));
+      expect(claimSet.payload, equals({"k": "v"}));
+      expect(claimSet.subject, "1234567890");
+      expect(claimSet.issuedAt,
+          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true));
+      expect(
+          claimSet.expiry,
+          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true)
+              .add(new Duration(days: 1)));
+    });
+
+    test('With payload: custom name', () {
+      String token =
+          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7ImsiOiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo=';
+      final JwtClaim claimSet =
+          verifyJwtHS256Signature(token, key, payloadName: 'customPayload');
       expect(claimSet.issuer, equals('teja'));
       expect(claimSet.audience, equals(["admin", "students"]));
       expect(claimSet.payload, equals({"k": "v"}));

--- a/jaguar_jwt/test/decoding/decoding_test.dart
+++ b/jaguar_jwt/test/decoding/decoding_test.dart
@@ -7,55 +7,166 @@ final key = 'secret';
 
 main() {
   group('Decoding', () {
-    test('Nopayload', () {
-      final String token =
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ==.sbsys3_L_Yc_L8S8KsiX3cBtQp34-jbX_eWhm6O8lxY=';
+    // Test JWT decoding using pre-encoded JWT values.
 
-      final JwtClaim claimSet = verifyJwtHS256Signature(token, key);
+    const secret = 's3cr3t';
 
-      expect(claimSet.issuer, equals('teja'));
-      expect(claimSet.subject, "1234567890");
-      expect(claimSet.audience, equals(["admin", "students"]));
+    //----------------------------------------------------------------
+
+    test('JWS example from RFC 7515', () {
+      // Example token from Appendix A.1. of "JSON Web Signature (JWS)" RFC 7515
+      // <https://tools.ietf.org/html/rfc7515#appendix-A.1>
+      //
+      // Payload is:
+      //     {"iss":"joe",
+      //      "exp":1300819380,
+      //      "http://example.com/is_root":true}
+
+      final token = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9'
+          '.'
+          'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
+          'cGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
+          '.'
+          'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
+      final k = 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75'
+          'aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow';
+
+      final issuer = 'joe';
+      final exp = new DateTime.utc(2011, 03, 22, 18, 43); // 1300819380
+
+      // Note: this secret is not a UTF-8 string
+      final hmacKey = String.fromCharCodes(B64urlEncRFC7515.decode(k));
+
+      // Verify signature
+
+      final JwtClaim claimSet = verifyJwtHS256Signature(token, hmacKey);
+
+      // Validate the claim set
+
+      // TODO: fix jaguar_jwt so this can validate
+      // currently, it always adds "iat" of the current time when the test is
+      // run, which makes this JWT non-sensible since it has an expiry time
+      // before when this test is run.
+
+      // claimSet.validate(
+      //    issuer: issuer,
+      //    currentTime: exp.subtract(const Duration(seconds: 60)));
+    });
+
+    //----------------------------------------------------------------
+
+    test('no payload', () {
+      // This JWT has an empty payload.
+
+      // TThe payload is the empty string. It is not even a JSON object.
+      // so while the signature validates, it cannot be converted into a claim
+      // set.
+
+      final token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..'
+          'iE8S5laiOzOYJxr411Fw2HrI9I-n2F8MREyuXFwqCDo'; // empty payload part
+      assert(B64urlEncRFC7515.decode(token.split('.')[1]).isEmpty); // no bytes
+
+      // TODO: impreove error reporting so this can tell why it is invalid
+      expect(() => verifyJwtHS256Signature(token, secret),
+          throwsA(equals(JwtException.invalidToken)));
+    });
+
+    //----------------------------------------------------------------
+
+    test('no claims', () {
+      // This JWT has no claims in its payload.
+      //
+      // The payload is the string "{}", which is a JSON object with no members.
+      // So there are no claims, not even 'iss', 'aud', 'iat' or 'exp'.
+
+      final token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+          'e30.'
+          'mwiDnq8rTFp5Oyy5i7pT8qktTB4tZOAfiJXTEbEqn2g';
+      assert(B64urlEncRFC7515.decodeUtf8(token.split('.')[1]) == '{}');
+
+      final claimSet = verifyJwtHS256Signature(token, secret);
+      expect(claimSet.issuer, isNull);
+      expect(claimSet.audience, isEmpty);
+      // Values for "iat" and "exp" are added during verification, which weren't
+      // in the JWT.
+      expect(claimSet.jwtId, isNull);
+      expect(claimSet.subject, isNull);
       expect(claimSet.payload, isEmpty);
-      expect(claimSet.issuedAt,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true));
-      expect(
-          claimSet.expiry,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true)
-              .add(new Duration(days: 1)));
     });
 
-    test('With payload: default name (pld)', () {
-      String token =
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIiOiIxMjM0NTY3ODkwIn0=.8C3WCOzfgAGvO7niu31HrkS_m883Vp8MSs7RMr9gN6g=';
-      final JwtClaim claimSet = verifyJwtHS256Signature(token, key);
-      expect(claimSet.issuer, equals('teja'));
-      expect(claimSet.audience, equals(["admin", "students"]));
-      expect(claimSet.payload, equals({"k": "v"}));
-      expect(claimSet.subject, "1234567890");
-      expect(claimSet.issuedAt,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true));
-      expect(
-          claimSet.expiry,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true)
-              .add(new Duration(days: 1)));
+    //----------------------------------------------------------------
+
+    // TODO: no other claims
+    // TODO: basic other claims
+
+    test('example with custom claim name', () {
+      // A more complicated JWT.
+
+      // {
+      //   "iss": "https://issuer.example.com",
+      //   "aud": [ "http://audience.example.com"],
+      //   "iat": 1547519119,
+      //   "nbf": 1547519119,
+      //   "exp": 1547519239,
+      //   "jti": "R4k4dsWcmS9pbpSmGHwCCeoh9RjGLfIg",
+      //   "sub": "https://example.com!http://localhost:10000!000abcdefghijklmnopqrstuvwxyz",
+      //   "https://aaf.edu.au/attributes": {
+      //     "auedupersonsharedtoken": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1",
+      //     "cn": John Bigboote,
+      //     "displayname": "John Bigboote",
+      //     "edupersonorcid": "http://orcid.org/0000-0000-0000-0000",
+      //     "edupersonprincipalname": jbigboote@example.com",
+      //     "edupersonscopedaffiliation": staff@example.com",
+      //     "edupersontargetedid": "https://example.com!http://localhost:10000!000abcdefghijklmnopqrstuvwxyz",
+      //     "givenname": "John,
+      //     "mail": "bigboote@example.com",
+      //     "surname": "Bigboote"
+      //     }
+      // }
+
+      final token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+          'eyJhdWQiOlsiaHR0cDovL2F1ZGllbmNlLmV4YW1wbGUuY29tIl0sImV4cCI6MTU0'
+          'NzUxOTIzOSwiaHR0cHM6Ly9hYWYuZWR1LmF1L2F0dHJpYnV0ZXMiOnsiYXVlZHVw'
+          'ZXJzb25zaGFyZWR0b2tlbiI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMSIs'
+          'ImNuIjoiSm9obiBCaWdib290ZSIsImRpc3BsYXluYW1lIjoiSm9obiBCaWdib290'
+          'ZSIsImVkdXBlcnNvbm9yY2lkIjoiaHR0cDovL29yY2lkLm9yZy8wMDAwLTAwMDAt'
+          'MDAwMC0wMDAwIiwiZWR1cGVyc29ucHJpbmNpcGFsbmFtZSI6ImpiaWdib290ZUBl'
+          'eGFtcGxlLmNvbSIsImVkdXBlcnNvbnNjb3BlZGFmZmlsaWF0aW9uIjoic3RhZmZA'
+          'ZXhhbXBsZS5jb20iLCJlZHVwZXJzb250YXJnZXRlZGlkIjoiaHR0cHM6Ly9leGFt'
+          'cGxlLmNvbSFodHRwOi8vbG9jYWxob3N0OjEwMDAwITAwMGFiY2RlZmdoaWprbG1u'
+          'b3BxcnN0dXZ3eHl6IiwiZ2l2ZW5uYW1lIjoiSm9obiIsIm1haWwiOiJiaWdib290'
+          'ZUBleGFtcGxlLmNvbSIsInN1cm5hbWUiOiJCaWdib290ZSJ9LCJpYXQiOjE1NDc1'
+          'MTkxMTksImlzcyI6Imh0dHBzOi8vaXNzdWVyLmV4YW1wbGUuY29tIiwianRpIjoi'
+          'UjRrNGRzV2NtUzlwYnBTbUdId0NDZW9oOVJqR0xmSWciLCJuYmYiOjE1NDc1MTkx'
+          'MTksInN1YiI6Imh0dHBzOi8vZXhhbXBsZS5jb20haHR0cDovL2xvY2FsaG9zdDox'
+          'MDAwMCEwMDBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eiJ9.'
+          'OlCUOj66oPagFoy0MOKvg5g86ts46mY6A2WhuVhi9c0';
+
+      final issuer = 'https://issuer.example.com';
+      final audience = 'http://audience.example.com';
+      final issuedAt = new DateTime.utc(2019, 1, 15, 2, 25, 19);
+      final expiry = new DateTime.utc(2019, 1, 15, 2, 27, 19);
+      final subject =
+          'https://example.com!http://localhost:10000!000abcdefghijklmnopqrstuvwxyz';
+      final jwtId = 'R4k4dsWcmS9pbpSmGHwCCeoh9RjGLfIg';
+
+      final secret = 's3cr3t';
+
+      // Verify the signature
+
+      final JwtClaim claimSet = verifyJwtHS256Signature(token, secret);
+
+      // Validate the claim set
+
+      claimSet.validate(
+          issuer: issuer,
+          audience: audience,
+          currentTime: issuedAt.add(const Duration(seconds: 5)));
+
+      expect(claimSet.subject, equals(subject));
+      expect(claimSet.jwtId, equals(jwtId));
     });
 
-    test('With payload: custom name', () {
-      String token =
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7ImsiOiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo=';
-      final JwtClaim claimSet =
-          verifyJwtHS256Signature(token, key, payloadName: 'customPayload');
-      expect(claimSet.issuer, equals('teja'));
-      expect(claimSet.audience, equals(["admin", "students"]));
-      expect(claimSet.payload, equals({"k": "v"}));
-      expect(claimSet.subject, "1234567890");
-      expect(claimSet.issuedAt,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true));
-      expect(
-          claimSet.expiry,
-          new DateTime.fromMillisecondsSinceEpoch(1481842800000, isUtc: true)
-              .add(new Duration(days: 1)));
-    });
   });
 }

--- a/jaguar_jwt/test/decoding/validation_test.dart
+++ b/jaguar_jwt/test/decoding/validation_test.dart
@@ -52,12 +52,12 @@ main() {
       // Validation of time claims
 
       // Values for testing sensible time claims:
-      // - notBefore can be any time, so using time the tests are run
+      // - notBefore can be any time, so using the time when tests are run
       // - issuedAt is 30 seconds before notBefore
       // - expiry is 60 seconds after notBefore
 
-      // TODO final notBefore = new DateTime.now();
-      final notBefore = new DateTime(2018, 12, 31, 17, 0, 0);
+      //final notBefore = new DateTime(2018, 12, 31, 23, 59, 59);
+      final notBefore = new DateTime.now();
       final issuedAt = notBefore.subtract(const Duration(seconds: 30));
       final expiry = notBefore.add(const Duration(seconds: 60));
 

--- a/jaguar_jwt/test/decoding/validation_test.dart
+++ b/jaguar_jwt/test/decoding/validation_test.dart
@@ -3,7 +3,7 @@ library test.validation;
 import 'package:test/test.dart';
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 
-main() {
+void main() {
   group('Validation', () {
     //================================================================
 
@@ -54,9 +54,10 @@ main() {
       test('Audience found', () {
         claimSetAudience1.validate(audience: audience1);
 
-        claimSetAudienceN.validate(audience: audience1);
-        claimSetAudienceN.validate(audience: audience2);
-        claimSetAudienceN.validate(audience: audience3);
+        claimSetAudienceN
+          ..validate(audience: audience1)
+          ..validate(audience: audience2)
+          ..validate(audience: audience3);
       });
 
       test('Audience not found', () {
@@ -294,7 +295,8 @@ main() {
               issuedAt: issuedAt,
               notBefore: notBefore,
               expiry: notBefore.subtract(smallDelay));
-          expect(() => weirdClaimSet.validate(),
+
+          expect(weirdClaimSet.validate,
               throwsA(equals(JwtException.invalidToken)));
         });
 
@@ -302,7 +304,7 @@ main() {
           // Token is never valid: as soon as it becomes accepted it also expires
           final weirdClaimSet = new JwtClaim(
               issuedAt: issuedAt, notBefore: notBefore, expiry: notBefore);
-          expect(() => weirdClaimSet.validate(),
+          expect(weirdClaimSet.validate,
               throwsA(equals(JwtException.invalidToken)));
         });
 
@@ -312,7 +314,7 @@ main() {
               issuedAt: issuedAt,
               notBefore: notBefore,
               expiry: issuedAt.subtract(smallDelay));
-          expect(() => weirdClaimSet.validate(),
+          expect(weirdClaimSet.validate,
               throwsA(equals(JwtException.invalidToken)));
         });
 
@@ -320,7 +322,7 @@ main() {
           // Who would issue a token that immediately expires?
           final weirdClaimSet = new JwtClaim(
               issuedAt: issuedAt, notBefore: notBefore, expiry: issuedAt);
-          expect(() => weirdClaimSet.validate(),
+          expect(weirdClaimSet.validate,
               throwsA(equals(JwtException.invalidToken)));
         });
       });
@@ -335,7 +337,14 @@ main() {
           // The notBefore time claim is redundant, since it is the same
           // value as the IssuedAt time claim. But it is a valid claim to make.
           final readyWhenIssuedClaimSet = new JwtClaim(
-              issuedAt: issuedAt, notBefore: issuedAt, expiry: expiry);
+              subject: 'testing.notBefore-at-issuedAt',
+              expiry: expiry,
+              notBefore: issuedAt,
+              issuedAt: issuedAt);
+          expect(readyWhenIssuedClaimSet.expiry, isNotNull);
+          expect(readyWhenIssuedClaimSet.notBefore, isNotNull);
+          expect(readyWhenIssuedClaimSet.issuedAt, isNotNull);
+
           readyWhenIssuedClaimSet.validate(
               currentTime: expiry.subtract(smallDelay)); // expect no exception
         });
@@ -351,9 +360,14 @@ main() {
           // "badly written" systems.
 
           final readyBeforeIssuedClaimSet = new JwtClaim(
-              issuedAt: issuedAt,
+              subject: 'testing.notBefore-before-issuedAt',
+              expiry: expiry,
               notBefore: issuedAt.subtract(smallDelay),
-              expiry: expiry);
+              issuedAt: issuedAt);
+          expect(readyBeforeIssuedClaimSet.expiry, isNotNull);
+          expect(readyBeforeIssuedClaimSet.notBefore, isNotNull);
+          expect(readyBeforeIssuedClaimSet.issuedAt, isNotNull);
+
           readyBeforeIssuedClaimSet.validate(
               currentTime: expiry.subtract(smallDelay)); // expect no exception
         });

--- a/jaguar_jwt/test/decoding/validation_test.dart
+++ b/jaguar_jwt/test/decoding/validation_test.dart
@@ -17,7 +17,7 @@ main() {
       claimSet.validate(audience: 'hello.com');
     });
 
-    test('Invorrect.Issuer', () {
+    test('Incorrect.Issuer', () {
       final claimSet = new JwtClaim(
           subject: 'kleak',
           issuer: 'hello.com',
@@ -28,7 +28,7 @@ main() {
           throwsA(equals(JwtException.incorrectIssuer)));
     });
 
-    test('Invorrect.Audience', () {
+    test('Incorrect.Audience', () {
       final claimSet = new JwtClaim(
           subject: 'kleak',
           issuer: 'hello.com',
@@ -44,6 +44,286 @@ main() {
           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIyIiwiYWNjb3VudElkIjoiYWNjb3VudDIifQ.FEqp-uESgVJn064zwiLFUlKlOKKN1eUkFmrJtu4HOWg";
       String secret = "localdev";
       verifyJwtHS256Signature(token, secret);
+    });
+
+    //----------------------------------------------------------------
+
+    group('Time claims', () {
+      // Validation of time claims
+
+      // Values for testing sensible time claims:
+      // - notBefore can be any time, so using time the tests are run
+      // - issuedAt is 30 seconds before notBefore
+      // - expiry is 60 seconds after notBefore
+
+      // TODO final notBefore = new DateTime.now();
+      final notBefore = new DateTime(2018, 12, 31, 17, 0, 0);
+      final issuedAt = notBefore.subtract(const Duration(seconds: 30));
+      final expiry = notBefore.add(const Duration(seconds: 60));
+
+      final smallDelay = const Duration(seconds: 1);
+      final bigDelay = const Duration(seconds: 11);
+      final maxSkew = const Duration(seconds: 10);
+
+      assert(smallDelay < maxSkew);
+      assert(maxSkew < bigDelay);
+
+      //----------------
+      group('With NotBefore', () {
+        // Claim set with all three time claims: IssuedAt, NotBefore, Expiry
+        final claimSet = new JwtClaim(
+            issuedAt: issuedAt, notBefore: notBefore, expiry: expiry);
+
+        test('Token constructed as expected', () {
+          expect(claimSet.notBefore, isNotNull);
+        });
+
+        test('Before IssuedAt: invalid (not yet issued)', () {
+          expect(
+              () =>
+                  claimSet.validate(currentTime: issuedAt.subtract(smallDelay)),
+              throwsA(equals(JwtException.tokenNotYetIssued)));
+        });
+
+        test('At IssuedAt: invalid (not yet accepted)', () {
+          // Actually, this has nothing to do with IssuedAt, but is invalid
+          // because it is before NotBefore. But the exception is different
+          // from when before IssuedAt.
+          expect(() => claimSet.validate(currentTime: issuedAt),
+              throwsA(equals(JwtException.tokenNotYetAccepted)));
+        });
+
+        test(
+            'Just After IssuedAt, but before NotBefore: invalid (not yet accepted)',
+            () {
+          final t = issuedAt.add(smallDelay);
+          assert(t.isBefore(notBefore));
+          expect(() => claimSet.validate(currentTime: t),
+              throwsA(equals(JwtException.tokenNotYetAccepted)));
+        });
+
+        test('Just before NotBefore: invalid (not yet accepted)', () {
+          final t = notBefore.subtract(smallDelay);
+          assert(t.isBefore(notBefore));
+          expect(() => claimSet.validate(currentTime: t),
+              throwsA(equals(JwtException.tokenNotYetAccepted)));
+        });
+
+        test('Just before NotBefore, allowing for clock skew: valid', () {
+          final t = notBefore.subtract(smallDelay);
+          assert(t.isBefore(notBefore));
+          claimSet.validate(currentTime: t, allowedClockSkew: maxSkew);
+        });
+
+        test('At NotBefore: valid', () {
+          claimSet.validate(currentTime: notBefore); //  expect no exception
+        });
+
+        test('Just after NotBefore but before Expiry: valid', () {
+          final t = notBefore.add(smallDelay);
+          assert(t.isBefore(expiry));
+          claimSet.validate(currentTime: t); // expect no exception
+        });
+
+        test('Just before Expires: valid', () {
+          final t = expiry.subtract(smallDelay);
+          claimSet.validate(currentTime: t);
+        });
+
+        test('At Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('At Expiry, allowing for clock skew: valid', () {
+          claimSet.validate(currentTime: expiry, allowedClockSkew: maxSkew);
+        });
+
+        test('Just after Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry.add(smallDelay)),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('Just after Expiry, allowing for clock skew: valid', () {
+          claimSet.validate(
+              currentTime: expiry.add(smallDelay), allowedClockSkew: maxSkew);
+        });
+
+        test('Way after Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry.add(bigDelay)),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('Way after Expiry, allowing for clock skew: invalid (expired)',
+            () {
+          expect(
+              () => claimSet.validate(
+                  currentTime: expiry.add(bigDelay), allowedClockSkew: maxSkew),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+      });
+
+      //----------------
+      group('Without notBefore', () {
+        // Claim set with only two time claims: IssuedAt, Expiry
+        //
+        // Note: the JwtClaim constructor uses default values for IssuedAt
+        // and Expires, if they are not provided. So it is not necessary (and
+        // impossible) to test the other combinations of only two or just one
+        // time claim.
+
+        final claimSet = new JwtClaim(issuedAt: issuedAt, expiry: expiry);
+
+        test('Token constructed as expected', () {
+          expect(claimSet.notBefore, isNull);
+        });
+
+        test('Before IssuedAt: invalid (not yet issued)', () {
+          expect(
+              () =>
+                  claimSet.validate(currentTime: issuedAt.subtract(smallDelay)),
+              throwsA(equals(JwtException.tokenNotYetIssued)));
+        });
+
+        test('At IssuedAt: valid', () {
+          claimSet.validate(currentTime: issuedAt);
+        });
+
+        test('Just After IssuedAt, but before Expires: valid', () {
+          final t = issuedAt.add(smallDelay);
+          claimSet.validate(currentTime: t);
+        });
+
+        test('Just before Expires: valid', () {
+          final t = expiry.subtract(smallDelay);
+          claimSet.validate(currentTime: t);
+        });
+
+        test('At Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('At Expiry, allowing for clock skew: valid', () {
+          claimSet.validate(currentTime: expiry, allowedClockSkew: maxSkew);
+        });
+
+        test('Just after Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry.add(smallDelay)),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('Just after Expiry, allowing for clock skew: valid', () {
+          claimSet.validate(
+              currentTime: expiry.add(smallDelay), allowedClockSkew: maxSkew);
+        });
+
+        test('Way after Expiry: invalid (expired)', () {
+          expect(() => claimSet.validate(currentTime: expiry.add(bigDelay)),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+
+        test('Way after Expiry, allowing for clock skew: invalid (expired)',
+            () {
+          expect(
+              () => claimSet.validate(
+                  currentTime: expiry.add(bigDelay), allowedClockSkew: maxSkew),
+              throwsA(equals(JwtException.tokenExpired)));
+        });
+      });
+
+      //----------------
+      group('Defaults', () {
+        // Claim set with no explicit time claims provided to the constructor
+        final claimSet = new JwtClaim();
+        final whenConstructorWasInvoked = new DateTime.now();
+
+        test('Token constructed as expected', () {
+          expect(claimSet.issuedAt, isNotNull); // default used
+          expect(claimSet.notBefore, isNull);
+          expect(claimSet.expiry, isNotNull); // default used
+
+          expect(claimSet.issuedAt.difference(whenConstructorWasInvoked),
+              lessThan(const Duration(seconds: 1)));
+        });
+      });
+
+      //----------------
+      group('Bad time claims', () {
+        // The following four tests checks the validation rejects tokens
+        // where the Expiry time is not sensible when compared to the IssuedAt
+        // and/or NotBefore times.
+
+        test('Expires before NotBefore', () {
+          // Token is never valid
+          final weirdClaimSet = new JwtClaim(
+              issuedAt: issuedAt,
+              notBefore: notBefore,
+              expiry: notBefore.subtract(smallDelay));
+          expect(() => weirdClaimSet.validate(),
+              throwsA(equals(JwtException.invalidToken)));
+        });
+
+        test('Expires at NotBefore', () {
+          // Token is never valid: as soon as it becomes accepted it also expires
+          final weirdClaimSet = new JwtClaim(
+              issuedAt: issuedAt, notBefore: notBefore, expiry: notBefore);
+          expect(() => weirdClaimSet.validate(),
+              throwsA(equals(JwtException.invalidToken)));
+        });
+
+        test('Expires before Issued', () {
+          // Who would issue a token that has already expired?
+          final weirdClaimSet = new JwtClaim(
+              issuedAt: issuedAt,
+              notBefore: notBefore,
+              expiry: issuedAt.subtract(smallDelay));
+          expect(() => weirdClaimSet.validate(),
+              throwsA(equals(JwtException.invalidToken)));
+        });
+
+        test('Expires at IssuedAt', () {
+          // Who would issue a token that immediately expires?
+          final weirdClaimSet = new JwtClaim(
+              issuedAt: issuedAt, notBefore: notBefore, expiry: issuedAt);
+          expect(() => weirdClaimSet.validate(),
+              throwsA(equals(JwtException.invalidToken)));
+        });
+      });
+
+      //----------------
+      group('Redundant time claims', () {
+        // The following two tests checks the validation does not reject tokens
+        // where the IssuedAt and NotBefore coincide or are in a different order
+        // to the situation tested above (where NotBefore is after IssuedAt).
+
+        test('NotBefore at IssuedAt', () {
+          // The notBefore time claim is redundant, since it is the same
+          // value as the IssuedAt time claim. But it is a valid claim to make.
+          final readyWhenIssuedClaimSet = new JwtClaim(
+              issuedAt: issuedAt, notBefore: issuedAt, expiry: expiry);
+          readyWhenIssuedClaimSet.validate(
+              currentTime: expiry.subtract(smallDelay)); // expect no exception
+        });
+
+        test('NotBefore before issuedAt', () {
+          // This seems like a strange situation, but it might occur if the token
+          // creation code is badly written. For example, claiming the token was
+          // issued correctly, but hardcoded to (redundantly) claim it has been
+          // valid since 1970-01-01.
+          //
+          // A strict implementation could reject this token, but the current
+          // implementation doesn't so it can still work with those
+          // "badly written" systems.
+
+          final readyBeforeIssuedClaimSet = new JwtClaim(
+              issuedAt: issuedAt,
+              notBefore: issuedAt.subtract(smallDelay),
+              expiry: expiry);
+          readyBeforeIssuedClaimSet.validate(
+              currentTime: expiry.subtract(smallDelay)); // expect no exception
+        });
+      });
     });
   });
 }

--- a/jaguar_jwt/test/encode/encode_test.dart
+++ b/jaguar_jwt/test/encode/encode_test.dart
@@ -1,14 +1,15 @@
 library test.encode;
 
+import 'dart:convert';
+
 import 'package:test/test.dart';
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 
 final key = 'secret';
 
 main() {
-  group('Encoding', () {
 
-    /*
+  group('Encoding', () {
     test('JWS example from RFC 7515', () {
       // Example token from Appendix A.1. of "JSON Web Signature (JWS)" RFC 7515
       // <https://tools.ietf.org/html/rfc7515#appendix-A.1>
@@ -21,6 +22,13 @@ main() {
       final k = 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75'
           'aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow';
 
+      const expectedJwt = 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9'
+          '.'
+          'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
+          'cGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
+          '.'
+          'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
       final issuer = 'joe';
       final exp = new DateTime.utc(2011, 03, 22, 18, 43); // 1300819380
 
@@ -29,73 +37,269 @@ main() {
 
       // Create JWT
 
-      final claimSet = new JwtClaim(issuer: issuer, expiry: exp);
-      final token = issueJwtHS256(claimSet, key);
-
-      // TODO: jaguar_jwt currently cannot replicate this JWT
-      // since it always adds 'iat' and 'exp' claims.
-      expect(
-          token,
-          equals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9'
-              '.'
-              'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
-              'cGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
-              '.'
-              'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'));
-    });
-    */
-
-    test('Nopayload', () {
       final claimSet = new JwtClaim(
-          issuer: 'teja',
-          subject: '1234567890',
-          audience: ["admin", "students"],
-          issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
-              isUtc: true));
-      String token = issueJwtHS256(claimSet, key);
-      expect(
-          token,
-          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
-              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
-              'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ.'
-              '3Ir0Af3-TFaC9gzgWVXvi0JJrhRzk95zFYEFmICw42k'));
+          issuer: issuer,
+          expiry: exp,
+          otherClaims: {'http://example.com/is_root': true},
+          defaultIatExp: false);
+      final token = issueJwtHS256(claimSet, hmacKey);
+
+      // This simple check won't work, since the encoded header and payloads are
+      // different strings, even though they both contain the same JSON object.
+      // That is because the values in the RFC example contains additional
+      // whitespace (newlines and spaces for indenting) and the ordering of the
+      // members may be different from what jaguar_jwt produces.
+      //     expect(token, equals(expectedJwt));
+      // Instead, check each of the parts separately.
+
+      // Split the JWTs into their parts
+
+      final expectedParts = expectedJwt.split('.');
+      assert(expectedParts.length == 3);
+
+      final parts = token.split('.');
+      expect(parts.length, equals(3));
+
+      // Check header
+
+      final expectedHeaderStr = B64urlEncRFC7515.decodeUtf8(expectedParts[0]);
+      final actualHeaderStr = B64urlEncRFC7515.decodeUtf8(parts[0]);
+      // print('Header produced by "jaguar_jwt": $actualHeaderStr');
+      // print('Header from example in RFC 7515: $expectedHeaderStr');
+
+      final expectedHeaderJson = json.decode(expectedHeaderStr);
+      final actualHeaderJson = json.decode(actualHeaderStr);
+
+      expect(actualHeaderJson, equals(expectedHeaderJson));
+
+      // Check payload
+
+      final expectedPayloadStr = B64urlEncRFC7515.decodeUtf8(expectedParts[1]);
+      final actualPayloadStr = B64urlEncRFC7515.decodeUtf8(parts[1]);
+      // print('Payload produced by "jaguar_jwt": $actualPayloadStr');
+      // print('Payload from example in RFC 7515: $expectedPayloadStr');
+
+      final expectedPayloadJson = json.decode(expectedPayloadStr);
+      final actualPayloadJson = json.decode(actualPayloadStr);
+
+      expect(actualPayloadJson, equals(expectedPayloadJson));
+
+      // Signatures will be different (since other parts are different)
+
+      expect(parts[2], isNot(equals(expectedParts[2])));
     });
 
-    test('With payload: default name (pld)', () {
-      final claimSet = new JwtClaim(
-          issuer: 'teja',
-          subject: '1234567890',
-          audience: ["admin", "students"],
-          issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
-              isUtc: true),
-          payload: {"k": "v"});
-      String token = issueJwtHS256(claimSet, key);
-      expect(
-          token,
-          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
-              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
-              'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIi'
-              'OiIxMjM0NTY3ODkwIn0.'
-              'R76R474_CwvEjkfT4WP1wL1X9PF9dp9oy5f7I3Z527U'));
+    //================================================================
+
+    group('Registered claims only', () {
+      test('Registered claims only', () {
+        final claimSet = new JwtClaim(
+            issuer: 'teja',
+            subject: '1234567890',
+            audience: ["admin", "students"],
+            issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
+                isUtc: true));
+        String token = issueJwtHS256(claimSet, key);
+        expect(
+            token,
+            equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+                'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
+                'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ.'
+                '3Ir0Af3-TFaC9gzgWVXvi0JJrhRzk95zFYEFmICw42k'));
+      });
+
+      test('Default iat and exp inserted', () {
+        // Without defaults
+
+        final csNoDefaults = new JwtClaim(defaultIatExp: false);
+        expect(csNoDefaults.containsKey('iat'), isFalse);
+        expect(csNoDefaults.issuedAt, isNull);
+        expect(csNoDefaults.containsKey('exp'), isFalse);
+        expect(csNoDefaults.expiry, isNull);
+        expect(csNoDefaults.notBefore, isNull); // nbf is never defaulted
+
+        // With defaults using the default maxAge
+
+        final beforeCreation = new DateTime.now();
+        final csWithDefaults = new JwtClaim();
+        final afterCreation = new DateTime.now();
+
+        expect(csWithDefaults.containsKey('iat'), isTrue);
+        expect(csWithDefaults.issuedAt, const TypeMatcher<DateTime>());
+        expect(csWithDefaults.containsKey('exp'), isTrue);
+        expect(csWithDefaults.expiry, const TypeMatcher<DateTime>());
+        expect(csNoDefaults.notBefore, isNull); // nbf is never defaulted
+
+        expect(csWithDefaults.issuedAt.isBefore(beforeCreation), isFalse);
+        expect(csWithDefaults.issuedAt.isAfter(afterCreation), isFalse);
+
+        final defaultMaxAlive =
+            csWithDefaults.expiry.difference(csWithDefaults.issuedAt);
+
+        expect(const Duration(minutes: 1) < defaultMaxAlive, isTrue,
+            reason: 'default maxAlive is too short: $defaultMaxAlive');
+        expect(defaultMaxAlive < const Duration(days: 7), isTrue,
+            reason: 'default maxAlive is too long: $defaultMaxAlive');
+        // in jaguar_jwt 2.1.5, the actual default maxAlive is 1 day
+
+        // With defaults and explicit maxAge
+
+        final currentTime = new DateTime.now();
+        final lifespan = const Duration(minutes: 1, seconds: 11);
+
+        final cs = new JwtClaim(issuedAt: currentTime, maxAge: lifespan);
+
+        // Note: issuedAt is in UTC, but currentTime is in localtime
+        expect(cs.issuedAt.isAtSameMomentAs(currentTime), isTrue);
+        expect(cs.expiry.isAtSameMomentAs(currentTime.add(lifespan)), isTrue);
+      });
     });
 
-    test('With payload: custom name', () {
-      final claimSet = new JwtClaim(
-          issuer: 'teja',
-          subject: '1234567890',
-          audience: ["admin", "students"],
-          issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
-              isUtc: true),
-          payloadName: 'customPayload',
-          payload: {"k": "v"});
-      String token = issueJwtHS256(claimSet, key);
-      expect(
-          token,
-          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
-              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7Imsi'
-              'OiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0'
-              'ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.'
-              'Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo'));
+    //================================================================
+
+    group('With unregistered claims', () {
+      // This group of tests demonstrates that the 'playload' and 'otherClaims'
+      // parameters can both be used to create the same JWT.
+
+      const expectedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+          'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
+          'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIi'
+          'OiIxMjM0NTY3ODkwIn0.'
+          'R76R474_CwvEjkfT4WP1wL1X9PF9dp9oy5f7I3Z527U';
+
+      test('Using payload parameter', () {
+        // Create a JWT with a 'pld' claim using the legacy "payload" parameter.
+        // NOTE: this approach has been deprecated.
+
+        final claimSet = new JwtClaim(
+            issuer: 'teja',
+            subject: '1234567890',
+            audience: ["admin", "students"],
+            issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
+                isUtc: true),
+            payload: {"k": "v"});
+        String token = issueJwtHS256(claimSet, key);
+        expect(token, equals(expectedToken));
+      });
+
+      test('Using otherClaims parameter', () {
+        // Create a JWT with a 'pld' claim using the "otherClaims" parameter.
+        // Produces exact same JWT as using the payload parameter did.
+
+        final claimSet = new JwtClaim(
+            issuer: 'teja',
+            subject: '1234567890',
+            audience: ["admin", "students"],
+            issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
+                isUtc: true),
+            otherClaims: {
+              'pld': {'k': 'v'}
+            });
+        String token = issueJwtHS256(claimSet, key);
+        expect(token, equals(expectedToken));
+      });
+
+      test('Using both payload and otherClaims is not allowed', () {
+        expect(
+            () => new JwtClaim(
+                issuer: 'teja',
+                subject: '1234567890',
+                audience: ["admin", "students"],
+                issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
+                    isUtc: true),
+                otherClaims: {
+                  'pld': {'k': 'v'}
+                },
+                payload: {"k": "v"} // with otherClaims['pld'] is not allowed
+                ),
+            throwsA(const TypeMatcher<ArgumentError>()));
+      });
+
+      test('Different value types', () {
+        const strWithSpaces = '  foo bar  BAZ  '; // multiple leading+trailing
+        const strWithUnicode = '美洲虎';
+
+        const mapValueNested = {
+          'alpha': true,
+          'beta': [1, 2, 3],
+          'gamma': {'w': 0, 'x': 0.0, 'y': 'Zero', 'z': []},
+          'delta': [
+            {'foo': 'bar'},
+            {'bar': 'baz'}
+          ],
+          'epsilon': {
+            'foo': [9, 8, 7],
+            'bar': ['a', 'b', 'c']
+          },
+        };
+
+        final source = new JwtClaim(issuer: 'issuer.example.com', otherClaims: {
+          'nullValue': null,
+          'boolValue0': false,
+          'boolValue1': true,
+          'intValueZero': 0,
+          'intValuePositive': 42,
+          'intValueNegative': -1,
+          'doubleValueZero': 0.0,
+          'doubleValuePositive': 3.14,
+          'doubleValueNegative': -2.7182,
+          'stringValueEmpty': '',
+          'stringValueWithSpaces': strWithSpaces,
+          'stringValueWithUnicode': strWithUnicode,
+          'listValue': [0, 1, 2, 3],
+          'mapValueEmpty': {},
+          'mapValueMixed': {'foo': 1, 'bar': 'string'},
+          'mapValueNested': mapValueNested,
+        });
+
+        final claimSet =
+            verifyJwtHS256Signature(issueJwtHS256(source, key), key);
+
+        // Claims with scalar values
+
+        expect(claimSet['nullValue'], isNull);
+        expect(claimSet['boolValue0'], equals(false));
+        expect(claimSet['boolValue1'], equals(true));
+        expect(claimSet['intValueZero'], equals(0));
+        expect(claimSet['intValuePositive'], equals(42));
+        expect(claimSet['intValueNegative'], equals(-1));
+        expect(claimSet['doubleValueZero'], equals(0));
+        expect(claimSet['doubleValuePositive'], equals(3.14));
+        expect(claimSet['doubleValueNegative'], equals(-2.7182));
+        expect(claimSet['stringValueEmpty'], equals(''));
+        expect(claimSet['stringValueWithSpaces'], equals(strWithSpaces));
+        expect(claimSet['stringValueWithUnicode'], equals(strWithUnicode));
+        expect(claimSet['listValue'], equals([0, 1, 2, 3]));
+        expect(claimSet['mapValueEmpty'], equals({}));
+        expect(claimSet['mapValueMixed'], equals({'bar': 'string', 'foo': 1}));
+        expect(claimSet['mapValueNested'], equals(mapValueNested));
+
+        // The list access operator cannot tell the difference between an
+        // absent claim and a claim with the value of null. But the containsKey
+        // method can.
+
+        expect(claimSet['nullValue'], isNull);
+        expect(claimSet['noSuchClaim'], isNull);
+        expect(claimSet.containsKey('nullValue'), isTrue);
+        expect(claimSet.containsKey('noSuchClaim'), isFalse);
+
+        // The list accessor operator can be used for the registered claims too.
+        // Though it is not normally used for this, since the member variables
+        // provide better type safety.
+
+        expect(claimSet['iss'], equals('issuer.example.com'));
+
+        expect(claimSet['iat'], const TypeMatcher<DateTime>());
+        expect(claimSet['exp'], const TypeMatcher<DateTime>());
+
+        // The list accessor operator treats the audience claim differently
+        // from the member when there is no audience: it returns null whereas
+        // the member is an empty list.
+
+        expect(claimSet.audience, const TypeMatcher<List<String>>());
+        expect(claimSet.audience, isEmpty);
+        expect(claimSet['aud'], isNull);
+      });
     });
   });
 }

--- a/jaguar_jwt/test/encode/encode_test.dart
+++ b/jaguar_jwt/test/encode/encode_test.dart
@@ -7,6 +7,44 @@ final key = 'secret';
 
 main() {
   group('Encoding', () {
+
+    /*
+    test('JWS example from RFC 7515', () {
+      // Example token from Appendix A.1. of "JSON Web Signature (JWS)" RFC 7515
+      // <https://tools.ietf.org/html/rfc7515#appendix-A.1>
+      //
+      // Payload is:
+      //     {"iss":"joe",
+      //      "exp":1300819380,
+      //      "http://example.com/is_root":true}
+
+      final k = 'AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75'
+          'aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow';
+
+      final issuer = 'joe';
+      final exp = new DateTime.utc(2011, 03, 22, 18, 43); // 1300819380
+
+      // Note: this secret is not a UTF-8 string
+      final hmacKey = String.fromCharCodes(B64urlEncRFC7515.decode(k));
+
+      // Create JWT
+
+      final claimSet = new JwtClaim(issuer: issuer, expiry: exp);
+      final token = issueJwtHS256(claimSet, key);
+
+      // TODO: jaguar_jwt currently cannot replicate this JWT
+      // since it always adds 'iat' and 'exp' claims.
+      expect(
+          token,
+          equals('eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9'
+              '.'
+              'eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt'
+              'cGxlLmNvbS9pc19yb290Ijp0cnVlfQ'
+              '.'
+              'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'));
+    });
+    */
+
     test('Nopayload', () {
       final claimSet = new JwtClaim(
           issuer: 'teja',
@@ -15,8 +53,12 @@ main() {
           issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
               isUtc: true));
       String token = issueJwtHS256(claimSet, key);
-      expect(token,
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ==.sbsys3_L_Yc_L8S8KsiX3cBtQp34-jbX_eWhm6O8lxY=');
+      expect(
+          token,
+          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
+              'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ.'
+              '3Ir0Af3-TFaC9gzgWVXvi0JJrhRzk95zFYEFmICw42k'));
     });
 
     test('With payload: default name (pld)', () {
@@ -28,8 +70,13 @@ main() {
               isUtc: true),
           payload: {"k": "v"});
       String token = issueJwtHS256(claimSet, key);
-      expect(token,
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIiOiIxMjM0NTY3ODkwIn0=.8C3WCOzfgAGvO7niu31HrkS_m883Vp8MSs7RMr9gN6g=');
+      expect(
+          token,
+          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlh'
+              'dCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIi'
+              'OiIxMjM0NTY3ODkwIn0.'
+              'R76R474_CwvEjkfT4WP1wL1X9PF9dp9oy5f7I3Z527U'));
     });
 
     test('With payload: custom name', () {
@@ -42,8 +89,13 @@ main() {
           payloadName: 'customPayload',
           payload: {"k": "v"});
       String token = issueJwtHS256(claimSet, key);
-      expect(token,
-          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7ImsiOiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo=');
+      expect(
+          token,
+          equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+              'eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7Imsi'
+              'OiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0'
+              'ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.'
+              'Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo'));
     });
   });
 }

--- a/jaguar_jwt/test/encode/encode_test.dart
+++ b/jaguar_jwt/test/encode/encode_test.dart
@@ -5,9 +5,9 @@ import 'dart:convert';
 import 'package:test/test.dart';
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 
-final key = 'secret';
+const String key = 'secret';
 
-main() {
+void main() {
 
   group('Encoding', () {
     test('JWS example from RFC 7515', () {
@@ -33,14 +33,14 @@ main() {
       final exp = new DateTime.utc(2011, 03, 22, 18, 43); // 1300819380
 
       // Note: this secret is not a UTF-8 string
-      final hmacKey = String.fromCharCodes(B64urlEncRFC7515.decode(k));
+      final hmacKey = String.fromCharCodes(B64urlEncRfc7515.decode(k));
 
       // Create JWT
 
       final claimSet = new JwtClaim(
           issuer: issuer,
           expiry: exp,
-          otherClaims: {'http://example.com/is_root': true},
+          otherClaims: <String,dynamic>{'http://example.com/is_root': true},
           defaultIatExp: false);
       final token = issueJwtHS256(claimSet, hmacKey);
 
@@ -62,25 +62,25 @@ main() {
 
       // Check header
 
-      final expectedHeaderStr = B64urlEncRFC7515.decodeUtf8(expectedParts[0]);
-      final actualHeaderStr = B64urlEncRFC7515.decodeUtf8(parts[0]);
+      final expectedHeaderStr = B64urlEncRfc7515.decodeUtf8(expectedParts[0]);
+      final actualHeaderStr = B64urlEncRfc7515.decodeUtf8(parts[0]);
       // print('Header produced by "jaguar_jwt": $actualHeaderStr');
       // print('Header from example in RFC 7515: $expectedHeaderStr');
 
-      final expectedHeaderJson = json.decode(expectedHeaderStr);
-      final actualHeaderJson = json.decode(actualHeaderStr);
+      final dynamic expectedHeaderJson = json.decode(expectedHeaderStr);
+      final dynamic actualHeaderJson = json.decode(actualHeaderStr);
 
       expect(actualHeaderJson, equals(expectedHeaderJson));
 
       // Check payload
 
-      final expectedPayloadStr = B64urlEncRFC7515.decodeUtf8(expectedParts[1]);
-      final actualPayloadStr = B64urlEncRFC7515.decodeUtf8(parts[1]);
+      final expectedPayloadStr = B64urlEncRfc7515.decodeUtf8(expectedParts[1]);
+      final actualPayloadStr = B64urlEncRfc7515.decodeUtf8(parts[1]);
       // print('Payload produced by "jaguar_jwt": $actualPayloadStr');
       // print('Payload from example in RFC 7515: $expectedPayloadStr');
 
-      final expectedPayloadJson = json.decode(expectedPayloadStr);
-      final actualPayloadJson = json.decode(actualPayloadStr);
+      final dynamic expectedPayloadJson = json.decode(expectedPayloadStr);
+      final dynamic actualPayloadJson = json.decode(actualPayloadStr);
 
       expect(actualPayloadJson, equals(expectedPayloadJson));
 
@@ -96,10 +96,10 @@ main() {
         final claimSet = new JwtClaim(
             issuer: 'teja',
             subject: '1234567890',
-            audience: ["admin", "students"],
+            audience: ['admin', 'students'],
             issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
                 isUtc: true));
-        String token = issueJwtHS256(claimSet, key);
+        final token = issueJwtHS256(claimSet, key);
         expect(
             token,
             equals('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
@@ -169,16 +169,17 @@ main() {
 
       test('Using payload parameter', () {
         // Create a JWT with a 'pld' claim using the legacy "payload" parameter.
+        //
         // NOTE: this approach has been deprecated.
 
         final claimSet = new JwtClaim(
             issuer: 'teja',
             subject: '1234567890',
-            audience: ["admin", "students"],
+            audience: ['admin', 'students'],
             issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
                 isUtc: true),
-            payload: {"k": "v"});
-        String token = issueJwtHS256(claimSet, key);
+            payload: <String,dynamic>{'k': 'v'});
+        final token = issueJwtHS256(claimSet, key);
         expect(token, equals(expectedToken));
       });
 
@@ -189,13 +190,13 @@ main() {
         final claimSet = new JwtClaim(
             issuer: 'teja',
             subject: '1234567890',
-            audience: ["admin", "students"],
+            audience: ['admin', 'students'],
             issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
                 isUtc: true),
-            otherClaims: {
+            otherClaims: <String,dynamic>{
               'pld': {'k': 'v'}
             });
-        String token = issueJwtHS256(claimSet, key);
+        final token = issueJwtHS256(claimSet, key);
         expect(token, equals(expectedToken));
       });
 
@@ -204,13 +205,14 @@ main() {
             () => new JwtClaim(
                 issuer: 'teja',
                 subject: '1234567890',
-                audience: ["admin", "students"],
+                audience: ['admin', 'students'],
                 issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
                     isUtc: true),
-                otherClaims: {
+                otherClaims: <String,dynamic>{
                   'pld': {'k': 'v'}
                 },
-                payload: {"k": "v"} // with otherClaims['pld'] is not allowed
+                // ignore: all
+                payload: <String,dynamic>{'k': 'v'} // conflicts otherClaims
                 ),
             throwsA(const TypeMatcher<ArgumentError>()));
       });
@@ -222,7 +224,7 @@ main() {
         const mapValueNested = {
           'alpha': true,
           'beta': [1, 2, 3],
-          'gamma': {'w': 0, 'x': 0.0, 'y': 'Zero', 'z': []},
+          'gamma': {'w': 0, 'x': 0.0, 'y': 'Zero', 'z': <Object>[]},
           'delta': [
             {'foo': 'bar'},
             {'bar': 'baz'}
@@ -233,7 +235,7 @@ main() {
           },
         };
 
-        final source = new JwtClaim(issuer: 'issuer.example.com', otherClaims: {
+        final source = new JwtClaim(issuer: 'issuer.example.com', otherClaims: <String,dynamic>{
           'nullValue': null,
           'boolValue0': false,
           'boolValue1': true,
@@ -247,7 +249,7 @@ main() {
           'stringValueWithSpaces': strWithSpaces,
           'stringValueWithUnicode': strWithUnicode,
           'listValue': [0, 1, 2, 3],
-          'mapValueEmpty': {},
+          'mapValueEmpty': <int,bool>{},
           'mapValueMixed': {'foo': 1, 'bar': 'string'},
           'mapValueNested': mapValueNested,
         });
@@ -270,7 +272,7 @@ main() {
         expect(claimSet['stringValueWithSpaces'], equals(strWithSpaces));
         expect(claimSet['stringValueWithUnicode'], equals(strWithUnicode));
         expect(claimSet['listValue'], equals([0, 1, 2, 3]));
-        expect(claimSet['mapValueEmpty'], equals({}));
+        expect(claimSet['mapValueEmpty'], equals(<int,bool>{}));
         expect(claimSet['mapValueMixed'], equals({'bar': 'string', 'foo': 1}));
         expect(claimSet['mapValueNested'], equals(mapValueNested));
 

--- a/jaguar_jwt/test/encode/encode_test.dart
+++ b/jaguar_jwt/test/encode/encode_test.dart
@@ -19,7 +19,7 @@ main() {
           r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInN1YiI6IjEyMzQ1Njc4OTAifQ==.sbsys3_L_Yc_L8S8KsiX3cBtQp34-jbX_eWhm6O8lxY=');
     });
 
-    test('With payload', () {
+    test('With payload: default name (pld)', () {
       final claimSet = new JwtClaim(
           issuer: 'teja',
           subject: '1234567890',
@@ -30,6 +30,20 @@ main() {
       String token = issueJwtHS256(claimSet, key);
       expect(token,
           r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJleHAiOjE0ODE5MjkyMDAsImlhdCI6MTQ4MTg0MjgwMCwiaXNzIjoidGVqYSIsInBsZCI6eyJrIjoidiJ9LCJzdWIiOiIxMjM0NTY3ODkwIn0=.8C3WCOzfgAGvO7niu31HrkS_m883Vp8MSs7RMr9gN6g=');
+    });
+
+    test('With payload: custom name', () {
+      final claimSet = new JwtClaim(
+          issuer: 'teja',
+          subject: '1234567890',
+          audience: ["admin", "students"],
+          issuedAt: new DateTime.fromMillisecondsSinceEpoch(1481842800000,
+              isUtc: true),
+          payloadName: 'customPayload',
+          payload: {"k": "v"});
+      String token = issueJwtHS256(claimSet, key);
+      expect(token,
+          r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiYWRtaW4iLCJzdHVkZW50cyJdLCJjdXN0b21QYXlsb2FkIjp7ImsiOiJ2In0sImV4cCI6MTQ4MTkyOTIwMCwiaWF0IjoxNDgxODQyODAwLCJpc3MiOiJ0ZWphIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.Hdu7W1AA1Ksubm5Bs9ra-DYE3UH62t6e5cjJ5zp7bzo=');
     });
   });
 }

--- a/jaguar_jwt/test/test_all.dart
+++ b/jaguar_jwt/test/test_all.dart
@@ -5,7 +5,7 @@ import 'decoding/decoding_test.dart' as decoding;
 import 'decoding/validation_test.dart' as validation;
 import 'encode/encode_test.dart' as encode;
 
-main() {
+void main() {
   decoding.main();
   encode.main();
   validation.main();


### PR DESCRIPTION
These changes:

+ Added support for optional Not Before Claim (`nbf`) (a registered claim from RFC 7519).
+ Fixed validation to reject token when current time exactly equals the Expiry time.
+ Added more unit tests.
+ Fixed generation of JWT to use correct _Base64url Encoding_. https://github.com/Jaguar-dart/session/issues/3
+ Added general support for non-registered claims. Multiple extra claims with any Claim Name (except for the Registered Claim Names). https://github.com/Jaguar-dart/session/issues/4
+ Added more verification checking. Since a JWT is usually obtained from a third party (possibly a malicious third party) there are no guarantees what it might contain.
+ Tidy up for static analysis and Dart linter. It now lints for nearly all 100+ linter rules (not just the ones currently in the _analysis_options.yaml_ file).
+ Implemented `toString` method for _JwtClaim_.
+ Added more documentation.

These changes should all be backward compatible, as long as code treats the _JwtClaim_ and any claim value extracted from it as immutable. That is, code would break if it did something very convoluted and strange like: create a _JwtClaim_ with no payload, use the _payload_ getter to retrieve its value (an empty Map is returned), add members to that Map, and then expect _issueJwtHS256_ to produce a JWT with a 'pld' claim with those added members.

One useful breaking change (that wasn't made) would be to make _JwtException_ implement _Exception_, and make the different exceptions subclasses, rather than rely on the String message to distinguish between them. Something to consider for the future.