### PR TITLE
Bug fixes

### DIFF
--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -9,6 +9,7 @@
 + Added general support for non-registered claims.
 + Tidy up for static analysis and Dart linter.
 + Implemented toString method for JwtClaim.
++ Allow for customized checking of the JWT header.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -10,6 +10,7 @@
 + Tidy up for static analysis and Dart linter.
 + Implemented toString method for JwtClaim.
 + Allow for customized checking of the JWT header.
++ Fixed use of _splayify/_spaly in toJson and changed dynamic to Object.
 
 ## 2.1.2
 

--- a/jaguar_jwt/CHANGELOG.md
+++ b/jaguar_jwt/CHANGELOG.md
@@ -11,6 +11,7 @@
 + Implemented toString method for JwtClaim.
 + Allow for customized checking of the JWT header.
 + Fixed use of _splayify/_spaly in toJson and changed dynamic to Object.
++ Improved format of output produced by JwtClaim.toString().
 
 ## 2.1.2
 

--- a/jaguar_jwt/analysis_options.yaml
+++ b/jaguar_jwt/analysis_options.yaml
@@ -1,7 +1,6 @@
-# This file allows you to configure the Dart analyzer.
+# Dart analyzer configuration for jaguar_jwt.
 #
-# The commented part below is just for inspiration. Read the guide here:
-#   https://www.dartlang.org/guides/language/analysis-options
+# See guide here: https://www.dartlang.org/guides/language/analysis-options
 
 analyzer:
   strong-mode:
@@ -12,9 +11,16 @@ linter:
   rules:
     # see catalog here: http://dart-lang.github.io/linter/lints/
     - always_put_control_body_on_new_line
+    - avoid_annotating_with_dynamic
     - camel_case_types
-    # - omit_local_variable_types
+    - omit_local_variable_types
+    # - only_throw_errors
     - prefer_single_quotes
     - public_member_api_docs
     - sort_constructors_first
     - type_annotate_public_apis
+
+# Note: the code actually satisify all the linter rules (not just the ones above),
+# except for these two:
+# - always_specify_types # this is the opposite of 'omit_local_variable_types'
+# - only_throw_errors # JwtException needs to change to satisify this rule

--- a/jaguar_jwt/analysis_options.yaml.complete
+++ b/jaguar_jwt/analysis_options.yaml.complete
@@ -1,0 +1,112 @@
+# Dart analyzer configuration for jaguar_jwt.
+#
+# See guide here: https://www.dartlang.org/guides/language/analysis-options
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    # see catalog here: http://dart-lang.github.io/linter/lints/
+    - always_declare_return_types
+    - always_put_control_body_on_new_line
+    - always_put_required_named_parameters_first
+    - always_require_non_null_named_parameters
+### - always_specify_types ## conflicts with omit_local_variable_types
+    - annotate_overrides
+    - avoid_annotating_with_dynamic
+    - avoid_as
+    - avoid_catches_without_on_clauses
+    - avoid_catching_errors
+    - avoid_classes_with_only_static_members
+    - avoid_empty_else
+    - avoid_function_literals_in_foreach_calls
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_positional_boolean_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null
+    - avoid_returning_this
+    - avoid_setters_without_getters
+    - avoid_slow_async_io
+    - avoid_types_on_closure_parameters
+    - avoid_unused_constructor_parameters
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    - cascade_invocations
+    - close_sinks
+    - comment_references
+    - constant_identifier_names
+    - control_flow_in_finally
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    - invariant_booleans
+    - iterable_contains_unrelated_type
+    - join_return_with_assignment
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    - omit_local_variable_types
+    - one_member_abstracts
+### - only_throw_errors
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - parameter_assignments
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    - prefer_bool_in_asserts
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_constructors_over_static_methods
+    - prefer_contains
+    - prefer_expression_function_bodies
+    - prefer_final_fields
+    - prefer_final_locals
+    - prefer_foreach
+    - prefer_function_declarations_over_variables
+    - prefer_initializing_formals
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
+    - public_member_api_docs
+    - recursive_getters
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
+    - super_goes_last
+    - test_types_in_equals
+    - throw_in_finally
+    - type_annotate_public_apis
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interps
+    - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_overrides
+    - unnecessary_statements
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    - use_setters_to_change_properties
+    - use_string_buffers
+    - use_to_and_as_if_applicable
+    - valid_regexps

--- a/jaguar_jwt/lib/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/jaguar_jwt.dart
@@ -10,7 +10,7 @@
 /// Currently, only the HMAC SHA-256 algorithm is supported to generate/process
 /// a JSON Web Signature (JWS).
 ///
-/// To generate a JWT, create a [JwtClaim] and use [issueJwtHS256]:
+/// To generate a JWT, create a `JwtClaim` and use [issueJwtHS256]:
 ///
 /// ```
 /// final claimSet = new JwtClaim(
@@ -18,7 +18,7 @@
 ///      subject: 'BD4A3FC4-9861-4171-8640-20C3004BD059',
 ///      audience: <String>['client1.example.com', 'client2.example.com'],
 ///      jwtId: _randomString(32),
-///      otherClaims: <String,dynamic>{
+///      otherClaims: <String, Object>{
 ///        'typ': 'authnresponse',
 ///        'pld': {'k': 'v'}
 ///      },
@@ -29,9 +29,9 @@
 /// final token = issueJwtHS256(claimSet, sharedSecret);
 /// ```
 ///
-/// To process a JWT, use [verifyJwtHS256Signature] to verify its signature
+/// To process a JWT, use `verifyJwtHS256Signature` to verify its signature
 /// and to extract a claim set from it, then verify the claim set using the
-/// [JwtClaim.validate] method before using the claims from it.
+/// `JwtClaim.validate` method before using the claims from it.
 ///
 /// ```
 /// const _expectedIssuer = 'issuer.example.com';

--- a/jaguar_jwt/lib/src/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/src/jaguar_jwt.dart
@@ -616,12 +616,74 @@ class JwtClaim {
   String toString() {
     final buf = StringBuffer('{\n');
 
+    var hadPrev = false;
     for (var claimName in claimNames(includeRegisteredClaims: true)) {
-      buf..write('  $claimName: ')..write(this[claimName])..write('\n');
+      if (hadPrev) {
+        buf.write(',\n');
+      }
+      buf.write(_toStringIndent);
+      _toStringDump(claimName, buf);
+      buf.write(': ');
+      _toStringDump(this[claimName], buf, 1);
+      hadPrev = true;
+    }
+    if (hadPrev) {
+      buf.write('\n');
     }
     buf.write('}');
 
     return buf.toString();
+  }
+
+  static const String _toStringIndent = '  ';
+
+  static void _toStringDump(Object value, StringBuffer buf, [int indent = 0]) {
+    if (value is Iterable<Object>) {
+      // Dump an Iterable
+      buf.write('[\n');
+      var hadPrev = false;
+      for (var v in value) {
+        if (hadPrev) {
+          buf.write(',\n');
+        }
+        buf.write(_toStringIndent * (indent + 1));
+        _toStringDump(v, buf, indent + 1);
+        hadPrev = true;
+      }
+      if (hadPrev) {
+        buf.write('\n');
+      }
+      buf..write(_toStringIndent * (indent))..write(']');
+    } else if (value is Map) {
+      // Dump a Map
+      buf.write('{\n');
+      var hadPrev = false;
+      for (var k in value.keys) {
+        if (hadPrev) {
+          buf.write(',\n');
+        }
+        buf.write(_toStringIndent * (indent + 1));
+        _toStringDump(k, buf, 0);
+        buf.write(': ');
+        _toStringDump(value[k], buf, indent + 1);
+        hadPrev = true;
+      }
+      if (hadPrev) {
+        buf.write('\n');
+      }
+      buf..write(_toStringIndent * (indent))..write('}');
+    } else if (value is String) {
+      // Dump a String value
+      final escValue = value..replaceAll('\\', '\\\\')..replaceAll('"', '\\"');
+      buf.write('"$escValue"');
+    } else if (value is DateTime) {
+      // Dump a DateTime value
+      buf.write('<$value>');
+      // buf.write('DateTime.parse("$value")');
+    } else {
+      // Dump some other
+      buf.write(value);
+    }
   }
 
   //================================================================

--- a/jaguar_jwt/lib/src/jaguar_jwt.dart
+++ b/jaguar_jwt/lib/src/jaguar_jwt.dart
@@ -146,7 +146,7 @@ class JwtClaim {
       Map<String, Object> otherClaims,
       @deprecated Map<String, Object> payload,
       bool defaultIatExp = true,
-      Duration maxAge: _defaultMaxAge})
+      Duration maxAge})
       : audience = audience ?? [],
         issuedAt = issuedAt?.toUtc() ??
             ((defaultIatExp) ? new DateTime.now().toUtc() : null),
@@ -154,7 +154,7 @@ class JwtClaim {
         expiry = expiry?.toUtc() ??
             ((defaultIatExp)
                 ? ((issuedAt?.toUtc() ?? new DateTime.now().toUtc())
-                    .add(maxAge))
+                    .add(maxAge ?? _defaultMaxAge))
                 : null) {
     // Check and record any non-registered claims
 
@@ -191,7 +191,7 @@ class JwtClaim {
   /// Throws [JwtException.invalidToken] if the Map is not suitable.
 
   factory JwtClaim.fromMap(Map<Object, Object> data,
-      {bool defaultIatExp = true, Duration maxAge = _defaultMaxAge}) {
+      {bool defaultIatExp = true, Duration maxAge}) {
     // Note: the map comes from parsing the payload into JSON, so we can't
     // guarantee what the types of its keys and values are.
 
@@ -500,16 +500,16 @@ class JwtClaim {
   /// An [allowedClockSkew] can be provided to allow for differences between
   /// the clock of the system that created the token and the clock of the system
   /// doing the validation. By default, there is no allowance for clock skew
-  /// (i.e. a duration of zero).
+  /// (i.e. it defaults to a duration of zero).
 
   void validate(
       {String issuer,
       String audience,
-      Duration allowedClockSkew: const Duration(), // zero = allow no clock skew
+      Duration allowedClockSkew,
       DateTime currentTime}) {
-    // Ensure clock skew is never negative
+    // Ensure clock skew has a value and is never negative
 
-    final absClockSkew = allowedClockSkew.abs();
+    final absClockSkew = allowedClockSkew?.abs() ?? const Duration();
 
     // Check Issuer Claim
     if (issuer is String && this.issuer != issuer)

--- a/jaguar_jwt/test/decoding/decoding_test.dart
+++ b/jaguar_jwt/test/decoding/decoding_test.dart
@@ -212,6 +212,28 @@ void main() {
       expect(claimSet.notBefore, equals(notBefore));
       expect(claimSet.issuedAt, equals(issuedAt));
       expect(claimSet.jwtId, equals(jwtId));
+
+      expect(claimSet['sub'], equals(subject));
+      expect(claimSet['exp'], equals(expiry));
+      expect(claimSet['nbf'], equals(notBefore));
+      expect(claimSet['iat'], equals(issuedAt));
+      expect(claimSet['jti'], equals(jwtId));
+
+      expect(claimSet.containsKey('sub'), isTrue);
+      expect(claimSet.containsKey('exp'), isTrue);
+      expect(claimSet.containsKey('nbf'), isTrue);
+      expect(claimSet.containsKey('iat'), isTrue);
+      expect(claimSet.containsKey('jti'), isTrue);
+
+      expect(claimSet.containsKey('no-such-claim'), isFalse);
+      expect(claimSet.containsKey(''), isFalse);
+      expect(claimSet.containsKey(null), isFalse);
+
+      expect(claimSet['no-such-claim'], isNull);
+      expect(claimSet[''], isNull);
+      expect(claimSet[null], isNull);
+
+
     });
 
     //================================================================

--- a/jaguar_jwt/test/decoding/decoding_test.dart
+++ b/jaguar_jwt/test/decoding/decoding_test.dart
@@ -40,7 +40,8 @@ void main() {
 
       // Verify signature
 
-      final claimSet = verifyJwtHS256Signature(token, hmacKey, defaultIatExp: false);
+      final claimSet =
+          verifyJwtHS256Signature(token, hmacKey, defaultIatExp: false);
       expect(claimSet, isNotNull);
 
       // Validate the claim set
@@ -222,7 +223,7 @@ void main() {
           audience: <String>[
             'audience.example.com'
           ],
-          otherClaims: <String,dynamic>{
+          otherClaims: <String, Object>{
             'pld': {'foo': 'bar'}
           });
 
@@ -273,7 +274,7 @@ void main() {
           '{"alg":"HS256","typ":"jwt"}': JwtException.invalidToken, // case diff
           '{"alg":"HS256","typ":"Jwt"}': JwtException.invalidToken, // case diff
           '{"alg":"HS256","typ":"JWt"}': JwtException.invalidToken, // case diff
-          // TODO: In RFC 7519, "JWT" is only RECOMMENDED. Other values are OK.
+          // Note: In RFC 7519, "JWT" is only RECOMMENDED. Other values are OK.
 
           // Semantically same JSON, but the hash is different
           '{"typ":"JWT","alg":"HS256"}': JwtException.hashMismatch,


### PR DESCRIPTION
Some bug fixes and small enhancements.

* Provided a mechanism for the programmer to change how the JOSE Header is checked (e.g. if they want to check for typ=='JWT' case insensitively, check for a different value, or not check it at all). But the default behaviour remains exactly the same as it was in v2.1.5 (case sensitive check).
* Fixed some bugs (I introduced in the previous pull request) and inefficiencies in the use of SplayTreeMap.
* Include a more complete _analysis_options.yaml_ file (as _analysis_options.yaml.complete_), for those who want to use it.
* Made the output of _toString_ format JwtClaims with nested Iterable/Map custom claims look better. Each member is shown on its own line.
* Changed the named optional parameters to work when they are set to null. That makes it less likely to be invoked incorrectly, and also does not expose the internal default value that will be used.
* Improved code by changing _dynamic_ to _Object_ where it is possible to do so; and added some linter "ignore" comments to silence the places where it must be used (namely, because Dart's JSON parser returns a dynamic).

Code has also been written to encode "aud" as a single string, instead of an array containing one string, when there is only one value for audience. And, obviously, using the array when there are more than one audience value. But this code has been commented out for the time being, because that would make the token different from the one produced by jaguar_jwt v2.1.5 (even though it is permitted by the JWT specification). Note: jaguar_jwt v2.1.5 does not accept such string 'aud' values when it tries to verify a JWT.

P.S. I think "test/test_all.dart" can be deleted. WebStorm and the command line ("pub run test") already provide ways to run all the tests in the _test_ directory.